### PR TITLE
Require parens around single arrow function parameters only for blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -145,7 +145,9 @@ module.exports = {
         "array-callback-return": "error",
         "arrow-body-style": "off",
         "arrow-parens": [
-            "error"
+            "error",
+            "as-needed",
+            { "requireForBlockBody": true }
         ],
         "arrow-spacing": [
             "error",


### PR DESCRIPTION
See http://eslint.org/docs/rules/arrow-parens for background.
