### PR TITLE
Update: always require radix in parseInt() [fix #3]

### DIFF
--- a/config.js
+++ b/config.js
@@ -295,7 +295,7 @@ module.exports = {
         "quotes": "off",
         "radix": [
             "error",
-            "as-needed"
+            "always"
         ],
         "require-jsdoc": "off",
         "require-yield": "error",


### PR DESCRIPTION
Avoid the opportunity for error by always requiring that the parseInt() radix
parameter be specified