### PR TITLE
Chore: test the lint configuration against itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/wikimedia/eslint-config-node-services#readme",
   "devDependencies": {
-    "eslint": "3.12.2"
+    "eslint": "^3.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint configuration for Wikimedia node.js services",
   "main": "config.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint -c config.js ."
   },
   "repository": {
     "type": "git",
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/wikimedia/eslint-config-node-services/issues"
   },
-  "homepage": "https://github.com/wikimedia/eslint-config-node-services#readme"
+  "homepage": "https://github.com/wikimedia/eslint-config-node-services#readme",
+  "devDependencies": {
+    "eslint": "3.12.2"
+  }
 }


### PR DESCRIPTION
It seems reasonable that the ESLint configuration pass its own requirements and
also prevent publishing an invalid config