### PR TITLE
New: forbid invalid JSON

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
         "es6": true,
         "node": true
     },
+    "plugins": ["json"],
     "rules": {
         "no-alert": "error",
         "no-array-constructor": "error",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.6",
   "description": "ESLint configuration for Wikimedia node.js services",
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint --ext .js --ext .json ."
   },
   "repository": {
     "type": "git",
@@ -19,7 +19,12 @@
     "url": "https://github.com/wikimedia/eslint-config-node-services/issues"
   },
   "homepage": "https://github.com/wikimedia/eslint-config-node-services#readme",
+  "peerDependencies": {
+    "eslint": "^3.12.0",
+    "eslint-plugin-json": "^1.2.0"
+  },
   "devDependencies": {
-    "eslint": "^3.12.0"
+    "eslint": "^3.12.0",
+    "eslint-plugin-json": "^1.2.0"
   }
 }


### PR DESCRIPTION
When linting JSON files with `--ext .json`, forbid invalids