### PR TITLE
New: add lint executable with expected defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ jspm_packages
 .node_repl_history
 
 .idea/**
+
+/.eslintcache

--- a/bin/node-services-lint
+++ b/bin/node-services-lint
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec eslint --cache --max-warnings 0 --ext .js --ext .json "$@"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "eslint-config-node-services",
   "version": "1.0.6",
   "description": "ESLint configuration for Wikimedia node.js services",
+  "bin": {
+    "node-services-lint": "bin/node-services-lint"
+  },
   "scripts": {
-    "test": "eslint --ext .js --ext .json ."
+    "test": "bin/node-services-lint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This tool has the recommended defaults for most projects fully complying
to the Node Services config. Ideally, projects will use this executable
as part of their NPM test script

Warnings are forbidden so clients must have clean code. The distinction
between warnings and errors is still quite useful in that warning level
issues may be permitted during development (often highlighted in yellow
within some editors) but may not be merged. This allows devs to avoid
hindrances during development and focus on polish at commit time