### PR TITLE
New: lint JSDocs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         "es6": true,
         "node": true
     },
-    "plugins": ["json"],
+    "plugins": ["jsdoc", "json"],
     "rules": {
         "no-alert": "error",
         "no-array-constructor": "error",
@@ -348,7 +348,15 @@ module.exports = {
         "yoda": [
             "error",
             "never"
-        ]
+        ],
+
+        // https://www.npmjs.com/package/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules
+        "jsdoc/check-param-names": "warn",
+        "jsdoc/check-tag-names": "warn",
+        "jsdoc/check-types": "warn",
+        "jsdoc/newline-after-description": ["warn", "never"],
+        "jsdoc/require-param-type": "warn",
+        "jsdoc/require-returns-type": "warn"
     },
     "parserOptions": {
         "ecmaVersion": 6,
@@ -357,6 +365,34 @@ module.exports = {
         }
     },
     "ecmaFeatures": {},
-    "extends": "eslint:recommended"
+    "extends": "eslint:recommended",
+    "settings": {
+        // https://www.npmjs.com/package/eslint-plugin-jsdoc#eslint-plugin-jsdoc-settings-alias-preference
+        "jsdoc": {
+            // one synonym for each ambiguity listed: http://usejsdoc.org/#block-tags
+            "tagNamePreference": {
+                abstract: "virtual",
+                arg: "param",
+                argument: "param",
+                augments: "extends",
+                constructor: "class",
+                constant: "const",
+                defaultvalue: "default",
+                description: "desc",
+                host: "external",
+                fileoverview: "file",
+                overview: "file",
+                fires: "emits",
+                function: "func",
+                method: "func",
+                member: "var",
+                property: "prop",
+                returns: "return",
+                exception: "throws",
+                linkcode: "link",
+                linkplain: "link"
+            }
+        }
+    }
 };
 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   "homepage": "https://github.com/wikimedia/eslint-config-node-services#readme",
   "peerDependencies": {
     "eslint": "^3.12.0",
+    "eslint-plugin-jsdoc": "^2.4.0",
     "eslint-plugin-json": "^1.2.0"
   },
   "devDependencies": {
     "eslint": "^3.12.0",
+    "eslint-plugin-jsdoc": "^2.4.0",
     "eslint-plugin-json": "^1.2.0"
   }
 }


### PR DESCRIPTION
When specified, JSDocs should be consistent:

• check-param-names: parameters documented must match those declared
• check-tag-names: forbid invalid JSDoc block tags
• check-types: forbid invalid types
• newline-after-description: forbid excess newlines after description
• require-param-type: parameters documented must specify type
• require-returns-type: return values documented must specify type

All rules new to this patch are emitted as warnings