### PR TITLE
Fix: export config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./.eslintrc')

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./.eslintrc')

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "eslint-config-node-services",
   "version": "2.0.0",
   "description": "ESLint configuration for Wikimedia node.js services",
+  "main": ".eslintrc.js",
   "scripts": {
     "test": "eslint --ext .js --ext .json .",
     "preversion": "[ -z \"$(git status --porcelain)\" ] && npm -s test",


### PR DESCRIPTION
Moving the ESLint config file to .eslintrc.js in c7d02a5 enabled
eslint-config-node-services itself to be linted generically but also
broke the export of the config. Add an index.js to export it.