### PR TITLE
Chore: add pre-commit test hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "eslint": "^3.12.0",
-    "eslint-plugin-json": "^1.2.0"
+    "eslint-plugin-json": "^1.2.0",
+    "pre-commit": "^1.2.2"
   }
 }


### PR DESCRIPTION
Require that new changes be linted before they're committed. This is a
useful requirement since the project does not have a CI build yet.