### PR TITLE
Extend wikimedia core config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,122 +7,60 @@ module.exports = {
     },
     "plugins": ["jsdoc", "json"],
     "rules": {
-        "no-alert": "error",
-        "no-array-constructor": "error",
-        "no-bitwise": "error",
-        "no-caller": "error",
-        "no-case-declarations": "error",
         "no-catch-shadow": "error",
-        "no-class-assign": "error",
-        "no-cond-assign": "error",
         "no-confusing-arrow": "error",
-        "no-console": "error",
-        "no-const-assign": "error",
-        "no-constant-condition": "error",
-        "no-continue": "off",
-        "no-control-regex": "error",
-        "no-debugger": "error",
-        "no-delete-var": "error",
-        "no-div-regex": "off",
-        "no-dupe-args": "error",
-        "no-dupe-class-members": "error",
-        "no-dupe-keys": "error",
-        "no-duplicate-case": "error",
         "no-duplicate-imports": "error",
-        "no-else-return": "off",
-        "no-empty": "error",
-        "no-empty-character-class": "error",
-        "no-empty-function": "off",
-        "no-empty-pattern": "error",
         "no-eq-null": "error",
-        "no-eval": "error",
-        "no-ex-assign": "error",
         "no-extend-native": "error",
         "no-extra-bind": "error",
-        "no-extra-boolean-cast": "error",
         "no-extra-label": "error",
-        "no-extra-parens": "warn",
-        "no-extra-semi": "error",
-        "no-fallthrough": "error",
         "no-floating-decimal": "error",
-        "no-func-assign": "error",
-        "no-global-assign": "error",
         "no-implicit-coercion": "off",
         "no-implicit-globals": "error",
-        "no-implied-eval": "error",
-        "no-inline-comments": "off",
-        "no-inner-declarations": "error",
-        "no-invalid-regexp": "error",
         "no-invalid-this": "error",
-        "no-irregular-whitespace": "error",
         "no-iterator": "error",
         "no-label-var": "error",
         "no-labels": "error",
         "no-lone-blocks": "error",
         "no-lonely-if": "error",
-        "no-loop-func": "error",
-        "no-magic-numbers": "off",
-        "no-mixed-operators": "off",
         "no-mixed-requires": "error",
-        "no-mixed-spaces-and-tabs": "error",
         "no-multi-spaces": "off",
         "no-multi-str": "error",
-        "no-multiple-empty-lines": "error",
+        "no-multiple-empty-lines": [
+            "error",
+            { "max": 2 }
+        ],
         "no-native-reassign": "error",
-        "no-negated-condition": "off",
         "no-negated-in-lhs": "error",
         "no-nested-ternary": "error",
-        "no-new": "error",
-        "no-new-func": "error",
-        "no-new-object": "error",
         "no-new-require": "error",
         "no-new-symbol": "error",
         "no-new-wrappers": "error",
-        "no-obj-calls": "error",
-        "no-octal": "error",
         "no-octal-escape": "error",
-        "no-param-reassign": "off",
         "no-path-concat": "error",
-        "no-plusplus": "off",
-        "no-process-env": "off",
-        "no-process-exit": "off",
         "no-proto": "error",
         "no-prototype-builtins": "error",
-        "no-redeclare": "error",
-        "no-regex-spaces": "error",
         "no-restricted-globals": "error",
         "no-restricted-imports": "error",
         "no-restricted-modules": "error",
         "no-restricted-properties": "error",
         "no-restricted-syntax": "error",
         "no-return-assign": "error",
-        "no-script-url": "error",
-        "no-self-assign": "error",
         "no-self-compare": "error",
         "no-sequences": "error",
-        "no-shadow": "off",
         "no-shadow-restricted-names": "error",
         "no-whitespace-before-property": "error",
         "no-spaced-func": "error",
         "no-sparse-arrays": "error",
-        "no-sync": "off",
         "no-tabs": "error",
-        "no-ternary": "off",
-        "no-trailing-spaces": "error",
+        "no-template-curly-in-string": "error",
         "no-this-before-super": "error",
         "no-throw-literal": "error",
-        "no-undef": "error",
         "no-undef-init": "error",
-        "no-undefined": "off",
-        "no-unexpected-multiline": "error",
         "no-underscore-dangle": "off",
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
-        "no-unreachable": "error",
-        "no-unsafe-finally": "error",
-        "no-unsafe-negation": "error",
         "no-unused-expressions": "error",
-        "no-unused-labels": "error",
         "no-unused-vars": [
             "error",
             { "args": "none" }
@@ -135,15 +73,11 @@ module.exports = {
         "no-useless-computed-key": "error",
         "no-useless-concat": "error",
         "no-useless-constructor": "error",
-        "no-useless-escape": "error",
         "no-useless-rename": "error",
         "no-void": "error",
         "no-var": "error",
-        "no-warning-comments": "off",
-        "no-with": "error",
         "array-bracket-spacing": "off",
         "array-callback-return": "error",
-        "arrow-body-style": "off",
         "arrow-parens": [
             "error",
             "as-needed",
@@ -158,58 +92,30 @@ module.exports = {
         ],
         "accessor-pairs": "error",
         "block-scoped-var": "error",
-        "block-spacing": [
-            "error",
-            "always"
-        ],
-        "brace-style": [
-            "error",
-            "1tbs",
-            {
-                "allowSingleLine": true
-            }
-        ],
-        "callback-return": "off",
         "camelcase": [
             "error",
             {
                 "properties": "never"
             }
         ],
-        "class-methods-use-this": "off",
         "comma-dangle": [
             "error",
             "only-multiline"
         ],
         "comma-spacing": "off",
-        "comma-style": [
-            "error",
-            "last"
-        ],
-        "complexity": "off",
         "computed-property-spacing": [
             "error",
             "never"
         ],
-        "consistent-return": "off",
         "consistent-this": "error",
-        "constructor-super": "error",
-        "curly": "error",
         "default-case": "error",
-        "dot-location": [
-            "error",
-            "property"
-        ],
         "dot-notation": [
             "error",
             {
                 "allowKeywords": true
             }
         ],
-        "eol-last": "error",
-        "eqeqeq": "error",
         "func-call-spacing": "error",
-        "func-names": "off",
         "func-style": [
             "error",
             "declaration",
@@ -218,31 +124,14 @@ module.exports = {
             }
         ],
         "generator-star-spacing": "error",
-        "global-require": "off",
         "guard-for-in": "error",
         "handle-callback-err": "error",
         "id-blacklist": "error",
-        "id-length": "off",
         "id-match": "error",
-        "indent": "error",
-        "init-declarations": "off",
+        "indent": [ "error", 4 ],
         "jsx-quotes": "error",
         "key-spacing": "off",
-        "keyword-spacing": [
-            "error",
-            {
-                "after": true,
-                "before": true
-            }
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "line-comment-position": "off",
-        "lines-around-comment": "off",
         "lines-around-directive": "error",
-        "max-depth": "off",
         "max-len": [
             "error",
             {
@@ -250,24 +139,10 @@ module.exports = {
                 "ignoreUrls": true
             }
         ],
-        "max-lines": "off",
         "max-nested-callbacks": "error",
-        "max-params": "off",
-        "max-statements": "off",
-        "max-statements-per-line": "off",
         "multiline-ternary": [
             "error",
             "never"
-        ],
-        "new-cap": "error",
-        "new-parens": "error",
-        "newline-after-var": "off",
-        "newline-before-return": "off",
-        "newline-per-chained-call": "off",
-        "object-curly-newline": "off",
-        "object-curly-spacing": [
-            "error",
-            "always"
         ],
         "object-property-newline": [
             "error",
@@ -286,13 +161,9 @@ module.exports = {
             "always"
         ],
         "operator-linebreak": "off",
-        "padded-blocks": "off",
         "prefer-arrow-callback": "error",
         "prefer-const": "error",
         "prefer-numeric-literals": "error",
-        "prefer-reflect": "off",
-        "prefer-rest-params": "off",
-        "prefer-spread": "off",
         "prefer-template": "error",
         "quote-props": "off",
         "quotes": "off",
@@ -300,21 +171,9 @@ module.exports = {
             "error",
             "always"
         ],
-        "require-jsdoc": "off",
-        "require-yield": "error",
         "rest-spread-spacing": "error",
-        "semi": "error",
-        "semi-spacing": [
-            "error",
-            {
-                "after": true,
-                "before": false
-            }
-        ],
-        "sort-keys": "off",
         "sort-imports": "error",
         "sort-vars": "error",
-        "space-before-blocks": "error",
         "space-before-function-paren": [
             "error",
             "never"
@@ -323,8 +182,6 @@ module.exports = {
             "error",
             "never"
         ],
-        "space-infix-ops": "error",
-        "space-unary-ops": "error",
         "spaced-comment": [
             "error",
             "always"
@@ -339,18 +196,8 @@ module.exports = {
             "error",
             "never"
         ],
-        "use-isnan": "error",
         "valid-jsdoc": "off",
-        "valid-typeof": "error",
-        "vars-on-top": "error",
-        "wrap-iife": "error",
-        "wrap-regex": "off",
-        "no-template-curly-in-string": "error",
         "yield-star-spacing": "error",
-        "yoda": [
-            "error",
-            "never"
-        ],
 
         // https://www.npmjs.com/package/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules
         "jsdoc/check-param-names": "warn",
@@ -367,7 +214,7 @@ module.exports = {
         }
     },
     "ecmaFeatures": {},
-    "extends": "eslint:recommended",
+    "extends": "wikimedia",
     "settings": {
         // https://www.npmjs.com/package/eslint-plugin-jsdoc#eslint-plugin-jsdoc-settings-alias-preference
         "jsdoc": {
@@ -397,4 +244,3 @@ module.exports = {
         }
     }
 };
-

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   "homepage": "https://github.com/wikimedia/eslint-config-node-services#readme",
   "peerDependencies": {
     "eslint": "^3.12.0",
+    "eslint-config-wikimedia": "^0.3.0",
     "eslint-plugin-jsdoc": "^3.0.0",
     "eslint-plugin-json": "^1.2.0"
   },
   "devDependencies": {
     "eslint": "^3.12.0",
+    "eslint-config-wikimedia": "^0.3.0",
     "eslint-plugin-jsdoc": "^3.0.0",
     "eslint-plugin-json": "^1.2.0",
     "pre-commit": "^1.2.2"


### PR DESCRIPTION
This shouldn't change any existing rules significantly but allows us to remove duplication. Also remove duplication from eslint:recommended.

Fixes #17