### PR TITLE
Remove redundant no-eq-null

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
         "no-catch-shadow": "error",
         "no-confusing-arrow": "error",
         "no-duplicate-imports": "error",
-        "no-eq-null": "error",
         "no-extend-native": "error",
         "no-extra-bind": "error",
         "no-extra-label": "error",


### PR DESCRIPTION
"wikimedia" ruleset has eqeqeq enabled which makes this rule redundant