### PR TITLE
Fix: remove ESLint incompatible option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -205,7 +205,6 @@ module.exports = {
             "globalReturn": true
         }
     },
-    "ecmaFeatures": {},
     "extends": "wikimedia",
     "settings": {
         // https://www.npmjs.com/package/eslint-plugin-jsdoc#eslint-plugin-jsdoc-settings-alias-preference


### PR DESCRIPTION
ecmaFeatures should be and is specified within parserOptions. Remove
duplicate conflicting outermost option which was causing the following
error in ESLint v4.1.1:

[object Object]:
        ESLint configuration is invalid:
        - Unexpected top-level property "ecmaFeatures".

Referenced from: /home/stephen/dev/wmf/wikimedia-page-library/.eslintrc.yml
Error: [object Object]:
        ESLint configuration is invalid:
        - Unexpected top-level property "ecmaFeatures".

Referenced from: /home/stephen/dev/wmf/wikimedia-page-library/.eslintrc.yml
    at validateConfigSchema (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config/config-validator.js:187:15)
    at Object.validate (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config/config-validator.js:200:5)
    at loadFromDisk (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config/config-file.js:549:19)
    at load (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config/config-file.js:592:20)
    at configExtends.reduceRight (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config/config-file.js:421:36)
    at Array.reduceRight (native)
    at applyExtends (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config/config-file.js:405:28)
    at loadFromDisk (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config/config-file.js:556:22)
    at Object.load (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config/config-file.js:592:20)
    at Config.getLocalConfigHierarchy (/home/stephen/dev/wmf/wikimedia-page-library/node_modules/eslint/lib/config.js:228:44)

This change appears to be compatible with ESLint v4.1.1 and ESLint
v3.12.2.

http://eslint.org/docs/user-guide/configuring#specifying-parser-options
https://github.com/eslint/eslint/issues/8726