### PR TITLE
Breaking: disallow async functions which have no await expression

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -161,6 +161,7 @@ module.exports = {
             "error",
             "always"
         ],
+        "require-await": "error",
         "rest-spread-spacing": "error",
         "sort-imports": "error",
         "sort-vars": "error",


### PR DESCRIPTION
Always remember to use `await`. It's easy to omit when refactoring and
be blind to the fact it's missing. Both these resolve with very
different results:

* `let resp = await apiUtil.mwApiGet(app, p.domain, query);`
* `let resp = apiUtil.mwApiGet(app, p.domain, query);`