### PR TITLE
Don't abbreviate WMF in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # eslint-config-node-services
-Simple config module for eslint, used by node services at WMF.
+Simple config module for eslint, used by node services at Wikimedia.
 
 Used by:
  - [RESTBase](https://github.com/wikimedia/restbase)


### PR DESCRIPTION
And...use "Wikimedia" instead, since this is nothing foundation specific.