### PR TITLE
Update dependencies and switch off chain indentation checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -118,7 +118,14 @@ module.exports = {
         "generator-star-spacing": "error",
         "guard-for-in": "error",
         "handle-callback-err": "error",
-        "indent": [ "error", 4, { "SwitchCase": 1 } ],
+        "indent": [
+            "error",
+            4,
+            {
+                "SwitchCase": 1,
+                "MemberExpression": "off"
+            }
+        ],
         "jsx-quotes": "error",
         "key-spacing": "off",
         "lines-around-directive": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-node-services",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "ESLint configuration for Wikimedia node.js services",
   "main": ".eslintrc.js",
   "scripts": {
@@ -23,15 +23,15 @@
   },
   "homepage": "https://github.com/wikimedia/eslint-config-node-services#readme",
   "peerDependencies": {
-    "eslint": "^3.12.0",
-    "eslint-config-wikimedia": "^0.4.0",
-    "eslint-plugin-jsdoc": "^3.0.0",
+    "eslint": "^4.12.0",
+    "eslint-config-wikimedia": "^0.5.0",
+    "eslint-plugin-jsdoc": "^3.2.0",
     "eslint-plugin-json": "^1.2.0"
   },
   "devDependencies": {
-    "eslint": "^3.12.0",
-    "eslint-config-wikimedia": "^0.4.0",
-    "eslint-plugin-jsdoc": "^3.0.0",
+    "eslint": "^4.12.0",
+    "eslint-config-wikimedia": "^0.5.0",
+    "eslint-plugin-jsdoc": "^3.2.0",
     "eslint-plugin-json": "^1.2.0",
     "pre-commit": "^1.2.2"
   }


### PR DESCRIPTION
The `MemberExpression` default has been changed in aslant apparently so now it wants us to indent `.then` blocks - switch it off. 0 here is not an option as it affects a lot more the `.then` and sometimes we want to indent in other cases.

cc @wikimedia/services 